### PR TITLE
Fix composer global command

### DIFF
--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -42,7 +42,7 @@ The `spress` executable is located at `/your-spress-repository-dir/bin`.
 You need to install Composer as before explained. 
 
 ```
-php composer.phar global require spress/Spress:1.*
+php composer.phar global require yosymfony/spress:1.*
 ```
 
 Next you have ready the `spress` command in your console. More information about


### PR DESCRIPTION
On "Getting started" page, replace "spress/Spress" with "yosymfony/spress"
